### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
 name: .NET
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/msufiaziz/demo-contacts/security/code-scanning/1](https://github.com/msufiaziz/demo-contacts/security/code-scanning/1)

To fix this issue, the recommended approach is to add a `permissions` block that defines the least privilege necessary for the workflow to function. Because the jobs in this particular workflow do not require write access to the repository or artifacts, you can set the top-level or job-level permissions to `contents: read`. This will ensure the `GITHUB_TOKEN` is limited to only read-access by default, and permissions can be increased for specific jobs if necessary in the future. 

To implement this, add the following near the top of your workflow YAML (after the `name` field and before `on:`). No other changes to methods, variables, or imports are required. Only a single YAML block needs to be inserted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
